### PR TITLE
Add admonition visitors to text renderer

### DIFF
--- a/bcdoc/textwriter.py
+++ b/bcdoc/textwriter.py
@@ -701,7 +701,7 @@ class TextTranslator(nodes.NodeVisitor):
         self.new_state(2)
     def _make_depart_admonition(name):
         def depart_admonition(self, node):
-            self.end_state(first=admonitionlabels[name] + ': ')
+            self.end_state(first=name.capitalize() + ': ')
         return depart_admonition
 
     visit_attention = _visit_admonition


### PR DESCRIPTION
Add admonition visitors to text renderer visitor.

This fixes the rendering issues on windows where warning nodes were triggering exceptions about being an unknown node.  This was lifted from the sphinx text renderer.
