### PR TITLE
Add breadcrumbs to HTML docs

### DIFF
--- a/bcdoc/clidocevents.py
+++ b/bcdoc/clidocevents.py
@@ -13,6 +13,7 @@
 
 
 DOC_EVENTS = {
+    'doc-breadcrumbs': '.%s.%s',
     'doc-title': '.%s.%s',
     'doc-description': '.%s.%s',
     'doc-synopsis-start': '.%s.%s',
@@ -40,6 +41,8 @@ def generate_events(session, help_command):
         session.register_event(event_name,
                                DOC_EVENTS[event_name])
     # Now generate the documentation events
+    fire_event(session, 'doc-breadcrumbs', help_command.event_class,
+               help_command.name, help_command=help_command)
     fire_event(session, 'doc-title', help_command.event_class,
                help_command.name, help_command=help_command)
     fire_event(session, 'doc-description', help_command.event_class,

--- a/bcdoc/clidocs.py
+++ b/bcdoc/clidocs.py
@@ -240,6 +240,18 @@ class OperationDocumentEventHandler(CLIDocumentEventHandler):
             d[operation.name] = operation.cli_name
         return d
 
+    def doc_breadcrumbs(self, help_command, event_name, **kwargs):
+        doc = help_command.doc
+        if doc.target != 'man':
+            l = event_name.split('.')
+            if len(l) > 1:
+                service_name = l[1]
+                doc.write('[ ')
+                doc.style.ref('aws', '../index')
+                doc.write(' . ')
+                doc.style.ref(service_name, 'index')
+                doc.write(' ]')
+
     def doc_title(self, help_command, **kwargs):
         doc = help_command.doc
         doc.style.h1(help_command.name)


### PR DESCRIPTION
Add a new event doc-breadcrumbs and a handler for the OperationDocumentEventHandler that creates links back to the service and to the provider but only for the MAN page.
