### PR TITLE
Escape hrefs

### DIFF
--- a/bcdoc/style.py
+++ b/bcdoc/style.py
@@ -186,6 +186,10 @@ class ReSTStyle(BaseStyle):
                     self.a_href = attr_value
                     self.doc.write('`')
         else:
+            # There are some model documentation that
+            # looks like this: <a>DescribeInstances</a>.
+            # In this case we just write out an empty
+            # string.
             self.doc.write(' ')
         self.doc.do_translation = True
 
@@ -198,6 +202,8 @@ class ReSTStyle(BaseStyle):
             last_write = self.doc.pop_write()
             last_write = last_write.rstrip(' ')
             if last_write:
+                if ':' in last_write:
+                    last_write = last_write.replace(':', r'\:')
                 self.doc.push_write(last_write)
                 self.doc.hrefs[last_write] = self.a_href
             else:

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -119,3 +119,14 @@ class TestStyle(unittest.TestCase):
         style.tocitem('bar')
         self.assertEqual(style.doc.getvalue(),
                          six.b('\n\n\n* foo\n\n\n* bar\n\n'))
+
+    def test_escape_href_link(self):
+        style = ReSTStyle(ReSTDocument())
+        style.start_a(attrs=[('href', 'http://example.org')])
+        style.doc.write('foo: the next bar')
+        style.end_a()
+        self.assertEqual(
+            style.doc.getvalue(),
+            six.b('`foo\\: the next bar`_ \n\n.. _foo\\: the next '
+                  'bar: http://example.org\n'))
+


### PR DESCRIPTION
The link titles must escape the `:` character because the link definition uses the `:` character to separate the title and the actual link.  If you don't this you'll get rendering errors whenever the link title has the `:` character.

First cleaned up the test module with some minor pep8 fixes.

Also change is: https://github.com/jamesls/bcdoc/commit/7d54d5381f4812859a59eb45052c0c839acc112f
