### PR TITLE
Account for hrefs with no text

### DIFF
--- a/bcdoc/style.py
+++ b/bcdoc/style.py
@@ -201,16 +201,24 @@ class ReSTStyle(BaseStyle):
         if self.a_href:
             last_write = self.doc.pop_write()
             last_write = last_write.rstrip(' ')
-            if last_write:
+            if last_write and last_write != '`':
                 if ':' in last_write:
                     last_write = last_write.replace(':', r'\:')
                 self.doc.push_write(last_write)
                 self.doc.hrefs[last_write] = self.a_href
+                self.doc.write('`_')
+            elif last_write == '`':
+                # Look at start_a().  It will do a self.doc.write('`')
+                # which is the start of the link title.  If that is the
+                # case then there was no link text.  We should just
+                # use an inline link.  The syntax of this is
+                # `<http://url>`_
+                self.doc.push_write('`<%s>`_' % self.a_href)
             else:
                 self.doc.push_write(self.a_href)
                 self.doc.hrefs[self.a_href] = self.a_href
+                self.doc.write('`_')
             self.a_href = None
-            self.doc.write('`_')
         self.doc.write(' ')
 
     def start_i(self, attrs=None):

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -130,3 +130,8 @@ class TestStyle(unittest.TestCase):
             six.b('`foo\\: the next bar`_ \n\n.. _foo\\: the next '
                   'bar: http://example.org\n'))
 
+    def test_handle_no_text_hrefs(self):
+        style = ReSTStyle(ReSTDocument())
+        style.start_a(attrs=[('href', 'http://example.org')])
+        style.end_a()
+        self.assertEqual(style.doc.getvalue(), six.b('`<http://example.org>`_ '))


### PR DESCRIPTION
When this happens we use the inline link, which in rst
is:

```
  `<http://thing>`_
```

Fixes aws/aws-cli#662
