### PR TITLE
Allow arguments to be undocumented

### DIFF
--- a/bcdoc/docevents.py
+++ b/bcdoc/docevents.py
@@ -52,6 +52,13 @@ def generate_events(session, help_command):
                help_command.name, help_command=help_command)
     if help_command.arg_table:
         for arg_name in help_command.arg_table:
+            # An argument can set an '_UNDOCUMENTED' attribute
+            # to True to indicate a parameter that exists
+            # but shouldn't be documented.  This can be used
+            # for backwards compatibility of deprecated arguments.
+            if getattr(help_command.arg_table[arg_name],
+                       '_UNDOCUMENTED', False):
+                continue
             fire_event(session, 'doc-synopsis-option',
                        help_command.event_class,
                        help_command.name, arg_name,
@@ -62,6 +69,9 @@ def generate_events(session, help_command):
                help_command.name, help_command=help_command)
     if help_command.arg_table:
         for arg_name in help_command.arg_table:
+            if getattr(help_command.arg_table[arg_name],
+                       '_UNDOCUMENTED', False):
+                continue
             fire_event(session, 'doc-option', help_command.event_class,
                        help_command.name, arg_name,
                        arg_name=arg_name, help_command=help_command)


### PR DESCRIPTION
We have this for commands, now we need this for arguments.

This is somewhat weird, but there's a CLI test to test this feature.
