### PR TITLE
Fix "warning: no files found matching 'README.md'"

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,3 @@
-include README.md
+include README.rst
 include LICENSE.txt
 include requirements.txt


### PR DESCRIPTION
The path of README file is wrong, so when you run
`$ pip install bcdoc`, you encounter the warning message as follows:

```
Downloading/unpacking bcdoc>=0.12.0,<0.13.0 (from awscli)
  Downloading bcdoc-0.12.2.tar.gz
  Running setup.py (path:/tmp/pip_build_vagrant/bcdoc/setup.py) egg_info for package bcdoc

    warning: no files found matching 'README.md'
```
