### PR TITLE
Add DocumentStructure class

### DIFF
--- a/bcdoc/compat.py
+++ b/bcdoc/compat.py
@@ -1,0 +1,17 @@
+# Copyright 2012-2013 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+try:
+    from collections import OrderedDict
+except ImportError:
+    # Python2.6 we use the 3rd party back port.
+    from ordereddict import OrderedDict

--- a/bcdoc/restdoc.py
+++ b/bcdoc/restdoc.py
@@ -103,21 +103,19 @@ class ReSTDocument(object):
 
 
 class DocumentStructure(ReSTDocument):
-    def __init__(self, name, event_emitter, section_names=None, target='man'):
+    def __init__(self, name, section_names=None, target='man'):
         """Provides a Hierarichial structure to a ReSTDocument
 
         You can write to it similiar to as you can to a ReSTDocument but
         has an innate structure for more orginaztion and abstraction.
 
         :param name: The name of the document
-        :param event_emitter: An event emitter used to emit events
         :param section_names: A list of sections to be included
             in the document.
         :parma target: The target documentation of the Document structure
         """
         super(DocumentStructure, self).__init__(target=target)
         self._name = name
-        self._event_emitter = event_emitter
         self._structure = OrderedDict()
         self._path = [self._name]
         if section_names is not None:
@@ -158,19 +156,13 @@ class DocumentStructure(ReSTDocument):
             to the document structure it was instantiated from.
         """
         # Add a new section
-        section = DocumentStructure(
-            name=name, event_emitter=self._event_emitter,
-            target=self.target)
+        section = self.__class__(name=name, target=self.target)
         section.path = self.path + [name]
         # Indent the section apporpriately as well
         section.style.indentation = self.style.indentation
         section.translation_map = self.translation_map
         section.hrefs = self.hrefs
         self._structure[name] = section
-        # Emit an event for handlers to hook into and edit the section
-        self._event_emitter.emit(
-            'docs-adding-section.%s' % '-'.join(section.path),
-            section=section)
         return section
 
     def get_section(self, name):
@@ -187,11 +179,6 @@ class DocumentStructure(ReSTDocument):
         The document is flushed out in a DFS style where sections and their
         subsections' values are added to the string as they are visited.
         """
-        # Recurse through all sections calling getvalue() to generate
-        # the section.
-        self._event_emitter.emit(
-            'docs-flushing-structure.%s' % '-'.join(self.path),
-            structure=self)
         # We are at the root flush the links at the beginning of the
         # document
         if len(self.path) == 1:

--- a/bcdoc/restdoc.py
+++ b/bcdoc/restdoc.py
@@ -11,6 +11,8 @@
 # ANY KIND, either express or implied. See the License for the specific
 # language governing permissions and limitations under the License.
 import logging
+
+from bcdoc.compat import OrderedDict
 from bcdoc.docstringparser import DocStringParser
 from bcdoc.style import ReSTStyle
 
@@ -98,3 +100,109 @@ class ReSTDocument(object):
         if self._last_doc_string is not None:
             start, end = self._last_doc_string
             del self._writes[start:end]
+
+
+class DocumentStructure(ReSTDocument):
+    def __init__(self, name, event_emitter, section_names=None, target='man'):
+        """Provides a Hierarichial structure to a ReSTDocument
+
+        You can write to it similiar to as you can to a ReSTDocument but
+        has an innate structure for more orginaztion and abstraction.
+
+        :param name: The name of the document
+        :param event_emitter: An event emitter used to emit events
+        :param section_names: A list of sections to be included
+            in the document.
+        :parma target: The target documentation of the Document structure
+        """
+        super(DocumentStructure, self).__init__(target=target)
+        self._name = name
+        self._event_emitter = event_emitter
+        self._structure = OrderedDict()
+        self._path = [self._name]
+        if section_names is not None:
+            self._generate_structure(section_names)
+
+    @property
+    def name(self):
+        """The name of the document structure"""
+        return self._name
+
+    @property
+    def path(self):
+        """
+        A list of where to find a particular document structure in the
+        overlying document structure.
+        """
+        return self._path
+
+    @path.setter
+    def path(self, value):
+        self._path = value
+
+    def _generate_structure(self, section_names):
+        for section_name in section_names:
+            self.add_new_section(section_name)
+
+    def add_new_section(self, name):
+        """Adds a new section to the current document structure
+
+        This document structure will be considered a section to the
+        current document structure but will in itself be an entirely
+        new document structure that can be written to and have sections
+        as well
+
+        :param name: The name of the section.
+        :rtype: DocumentStructure
+        :returns: A new document structure to add to but lives as a section
+            to the document structure it was instantiated from.
+        """
+        # Add a new section
+        section = DocumentStructure(
+            name=name, event_emitter=self._event_emitter,
+            target=self.target)
+        section.path = self.path + [name]
+        # Indent the section apporpriately as well
+        section.style.indentation = self.style.indentation
+        section.translation_map = self.translation_map
+        section.hrefs = self.hrefs
+        self._structure[name] = section
+        # Emit an event for handlers to hook into and edit the section
+        self._event_emitter.emit(
+            'docs-adding-section.%s' % '-'.join(section.path),
+            section=section)
+        return section
+
+    def get_section(self, name):
+        """Retrieve a section"""
+        return self._structure[name]
+
+    def delete_section(self, name):
+        """Delete a section"""
+        del self._structure[name]
+
+    def flush_structure(self):
+        """Flushes a doc structure to a ReSTructed string
+
+        The document is flushed out in a DFS style where sections and their
+        subsections' values are added to the string as they are visited.
+        """
+        # Recurse through all sections calling getvalue() to generate
+        # the section.
+        self._event_emitter.emit(
+            'docs-flushing-structure.%s' % '-'.join(self.path),
+            structure=self)
+        # We are at the root flush the links at the beginning of the
+        # document
+        if len(self.path) == 1:
+            if self.hrefs:
+                self.style.new_paragraph()
+                for refname, link in self.hrefs.items():
+                    self.style.link_target_definition(refname, link)
+        value = self.getvalue()
+        for name, section in self._structure.items():
+            value += section.flush_structure()
+        return value
+
+    def getvalue(self):
+        return ''.join(self._writes).encode('utf-8')

--- a/bcdoc/style.py
+++ b/bcdoc/style.py
@@ -24,6 +24,14 @@ class BaseStyle(object):
         self._indent = 0
         self.keep_data = True
 
+    @property
+    def indentation(self):
+        return self._indent
+
+    @indentation.setter
+    def indentation(self, value):
+        self._indent = value
+
     def new_paragraph(self):
         return '\n%s' % self.spaces()
 
@@ -323,3 +331,38 @@ class ReSTStyle(BaseStyle):
     def hidden_tocitem(self, item):
         if self.doc.target == 'html':
             self.tocitem(item)
+
+    def table_of_contents(self, title=None, depth=None):
+        self.doc.write('.. contents:: ')
+        if title is not None:
+            self.doc.writeln(title)
+        if depth is not None:
+            self.doc.writeln('   :depth: %s' % depth)
+
+    def start_sphinx_py_class(self, class_name):
+        self.new_paragraph()
+        self.doc.write('.. py:class:: %s' % class_name)
+        self.indent()
+        self.new_paragraph()
+
+    def end_sphinx_py_class(self):
+        self.dedent()
+        self.new_paragraph()
+
+    def start_sphinx_py_method(self, method_name, parameters=None):
+        self.new_paragraph()
+        content = '.. py:method:: %s' % method_name
+        if parameters is not None:
+            content += '(%s)' % parameters
+        self.doc.write(content)
+        self.indent()
+        self.new_paragraph()
+
+    def end_sphinx_py_method(self):
+        self.dedent()
+        self.new_paragraph()
+
+    def write_py_doc_string(self, docstring):
+        docstring_lines = docstring.splitlines()
+        for docstring_line in docstring_lines:
+            self.doc.writeln(docstring_line)

--- a/requirements26.txt
+++ b/requirements26.txt
@@ -1,1 +1,2 @@
 unittest2==0.8.0
+ordereddict==1.1

--- a/setup.py
+++ b/setup.py
@@ -17,6 +17,11 @@ packages = [
 requires = ['six>=1.8.0,<2.0.0',
             'docutils>=0.10']
 
+if sys.version_info[:2] == (2, 6):
+    # For python2.6 we have a few other dependencies.
+    # First we need an ordered dictionary so we use the
+    # 2.6 backport.
+    requires.append('ordereddict==1.1')
 
 setup(
     name='bcdoc',

--- a/setup.py
+++ b/setup.py
@@ -3,6 +3,8 @@
 """
 distutils/setuptools install script.
 """
+import sys
+
 
 try:
     from setuptools import setup

--- a/tests/unit/test_document.py
+++ b/tests/unit/test_document.py
@@ -21,7 +21,6 @@
 # IN THE SOFTWARE.
 #
 import six
-import mock
 
 from tests import unittest
 from bcdoc.restdoc import ReSTDocument, DocumentStructure

--- a/tests/unit/test_document.py
+++ b/tests/unit/test_document.py
@@ -23,8 +23,9 @@
 import unittest
 
 import six
+import mock
 
-from bcdoc.restdoc import ReSTDocument
+from bcdoc.restdoc import ReSTDocument, DocumentStructure
 
 
 class TestReSTDocument(unittest.TestCase):
@@ -50,4 +51,116 @@ class TestReSTDocument(unittest.TestCase):
         doc.include_doc_string('<p>this is a <code>test</code></p>')
         doc.remove_last_doc_string()
         self.assertEqual(doc.getvalue(), six.b('foo\n'))
-        
+
+
+class TestDocumentStructure(unittest.TestCase):
+    def setUp(self):
+        self.name = 'mydoc'
+        self.event_emitter = mock.Mock()
+        self.doc_structure = DocumentStructure(
+            self.name, self.event_emitter)
+
+    def test_name(self):
+        self.assertEqual(self.doc_structure.name, self.name)
+
+    def test_path(self):
+        self.assertEqual(self.doc_structure.path, [self.name])
+        self.doc_structure.path = ['foo']
+        self.assertEqual(self.doc_structure.path, ['foo'])
+
+    def test_add_new_section(self):
+        section = self.doc_structure.add_new_section('mysection')
+
+        # Ensure the name of the section is correct
+        self.assertEqual(section.name, 'mysection')
+
+        # Ensure we can get the section.
+        self.assertEqual(
+            self.doc_structure.get_section('mysection'), section)
+
+        # Ensure the path is correct
+        self.assertEqual(section.path, ['mydoc', 'mysection'])
+
+        # Ensure some of the necessary attributes are passed to the
+        # the section.
+        self.assertEqual(section.style.indentation,
+                         self.doc_structure.style.indentation)
+        self.assertEqual(section.translation_map,
+                         self.doc_structure.translation_map)
+        self.assertEqual(section.hrefs,
+                         self.doc_structure.hrefs)
+
+        # Ensure the event fired is as expected
+        events_called = self.event_emitter.emit.call_args_list
+        self.assertEqual(len(events_called), 1)
+        self.assertEqual(
+            events_called[0],
+            mock.call('docs-adding-section.mydoc-mysection', section=section))
+
+    def test_delete_section(self):
+        section = self.doc_structure.add_new_section('mysection')
+        self.assertEqual(
+            self.doc_structure.get_section('mysection'), section)
+        self.doc_structure.delete_section('mysection')
+        with self.assertRaises(KeyError):
+            section.get_section('mysection')
+
+    def test_create_sections_at_instantiation(self):
+        sections = ['intro', 'middle', 'end']
+        self.doc_structure = DocumentStructure(
+            self.name, self.event_emitter, section_names=sections)
+        events_called = self.event_emitter.emit.call_args_list
+
+        # Ensure the sections are created, exist, and are emitted.
+        self.assertEqual(len(events_called), 3)
+        for i, section in enumerate(sections):
+            self.assertEqual(
+                events_called[i],
+                mock.call('docs-adding-section.mydoc-%s' % section,
+                          section=self.doc_structure.get_section(section)))
+
+    def test_flush_structure(self):
+        section = self.doc_structure.add_new_section('mysection')
+        subsection = section.add_new_section('mysubsection')
+        self.doc_structure.writeln('1')
+        section.writeln('2')
+        subsection.writeln('3')
+        second_section = self.doc_structure.add_new_section('mysection2')
+        second_section.writeln('4')
+        contents = self.doc_structure.flush_structure()
+
+        # Ensure the contents were flushed out correctly
+        self.assertEqual(contents, six.b('1\n2\n3\n4\n'))
+
+        # Ensure the sections are emitted.
+        events_called = self.event_emitter.emit.call_args_list
+        self.assertEqual(len(events_called), 7)
+        events_called = events_called[3:]
+        self.assertEqual(
+            events_called[0],
+            mock.call('docs-flushing-structure.mydoc',
+                      structure=self.doc_structure))
+        self.assertEqual(
+            events_called[1],
+            mock.call('docs-flushing-structure.mydoc-mysection',
+                      structure=section))
+        self.assertEqual(
+            events_called[2],
+            mock.call('docs-flushing-structure.mydoc-mysection-mysubsection',
+                      structure=subsection))
+        self.assertEqual(
+            events_called[3],
+            mock.call('docs-flushing-structure.mydoc-mysection2',
+                      structure=second_section))
+
+    def test_flush_structure_hrefs(self):
+        section = self.doc_structure.add_new_section('mysection')
+        section.writeln('section contents')
+        self.doc_structure.hrefs['foo'] = 'www.foo.com'
+        section.hrefs['bar'] = 'www.bar.com'
+        contents = self.doc_structure.flush_structure()
+        self.assertEqual(
+            contents,
+            six.b('\n\n.. _foo: www.foo.com\n.. _bar: www.bar.com\n'
+                  'section contents\n')
+        )

--- a/tests/unit/test_document.py
+++ b/tests/unit/test_document.py
@@ -20,11 +20,10 @@
 # OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS
 # IN THE SOFTWARE.
 #
-import unittest
-
 import six
 import mock
 
+from tests import unittest
 from bcdoc.restdoc import ReSTDocument, DocumentStructure
 
 
@@ -159,8 +158,5 @@ class TestDocumentStructure(unittest.TestCase):
         self.doc_structure.hrefs['foo'] = 'www.foo.com'
         section.hrefs['bar'] = 'www.bar.com'
         contents = self.doc_structure.flush_structure()
-        self.assertEqual(
-            contents,
-            six.b('\n\n.. _foo: www.foo.com\n.. _bar: www.bar.com\n'
-                  'section contents\n')
-        )
+        self.assertIn(six.b('.. _foo: www.foo.com'), contents)
+        self.assertIn(six.b('.. _bar: www.bar.com'), contents)

--- a/tests/unit/test_style.py
+++ b/tests/unit/test_style.py
@@ -181,3 +181,51 @@ class TestStyle(unittest.TestCase):
         style.doc.target = 'man'
         style.sphinx_reference_label('foo')
         self.assertEqual(style.doc.getvalue(), six.b('foo'))
+
+    def test_table_of_contents(self):
+        style = ReSTStyle(ReSTDocument())
+        style.table_of_contents()
+        self.assertEqual(style.doc.getvalue(), six.b('.. contents:: '))
+
+    def test_table_of_contents_with_title(self):
+        style = ReSTStyle(ReSTDocument())
+        style.table_of_contents(title='Foo')
+        self.assertEqual(style.doc.getvalue(), six.b('.. contents:: Foo\n'))
+
+    def test_table_of_contents_with_title_and_depth(self):
+        style = ReSTStyle(ReSTDocument())
+        style.table_of_contents(title='Foo', depth=2)
+        self.assertEqual(style.doc.getvalue(),
+                         six.b('.. contents:: Foo\n   :depth: 2\n'))
+
+    def test_sphinx_py_class(self):
+        style = ReSTStyle(ReSTDocument())
+        style.start_sphinx_py_class('FooClass')
+        style.end_sphinx_py_class()
+        self.assertEqual(style.doc.getvalue(),
+                         six.b('\n\n.. py:class:: FooClass\n\n  \n\n'))
+
+    def test_sphinx_py_method(self):
+        style = ReSTStyle(ReSTDocument())
+        style.start_sphinx_py_method('method')
+        style.end_sphinx_py_method()
+        self.assertEqual(style.doc.getvalue(),
+                         six.b('\n\n.. py:method:: method\n\n  \n\n'))
+
+    def test_sphinx_py_method_with_params(self):
+        style = ReSTStyle(ReSTDocument())
+        style.start_sphinx_py_method('method', 'foo=None')
+        style.end_sphinx_py_method()
+        self.assertEqual(
+            style.doc.getvalue(),
+            six.b('\n\n.. py:method:: method(foo=None)\n\n  \n\n'))
+
+    def test_write_py_doc_string(self):
+        style = ReSTStyle(ReSTDocument())
+        docstring = (
+            'This describes a function\n'
+            ':param foo: Describes foo\n'
+            'returns: None'
+        )
+        style.write_py_doc_string(docstring)
+        self.assertEqual(style.doc.getvalue(), six.b(docstring + '\n'))


### PR DESCRIPTION
Adds an hierarchial abstraction on the ReSTDocument class that allows for better orginization and modification of the general document. Also added some additional helper methods for documenting sphinx python class and method references.

This is needed for the work that I am adding for the botocore documentation that will be coming soon.

Specifically getting feedback on the emitting of events when sections are added and the structure is flushed out would be great. I am leaning toward getting rid of the events and have whatever project is being used emit the events that they want to emit.

cc @jamesls 